### PR TITLE
Add interactive comic reader

### DIFF
--- a/components/ui/ComicReader.tsx
+++ b/components/ui/ComicReader.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import Image from 'next/image';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/css';
+
+interface ComicPage {
+  image: string;
+  caption: string;
+}
+
+const pages: ComicPage[] = [
+  {
+    image: '/hero/slide1.jpg',
+    caption: 'Primer panel del cuento',
+  },
+  {
+    image: '/hero/slide2.jpg',
+    caption: 'Segundo panel del cuento',
+  },
+  {
+    image: '/hero/slide3.jpg',
+    caption: 'Tercer panel del cuento',
+  },
+  {
+    image: '/hero/slide4.jpg',
+    caption: 'Cuarto panel del cuento',
+  },
+];
+
+export default function ComicReader() {
+  const [mode, setMode] = useState<'vertical' | 'panel'>('vertical');
+  const [active, setActive] = useState<number | null>(null);
+
+  const speak = (text: string) => {
+    if (typeof window !== 'undefined') {
+      const utterance = new SpeechSynthesisUtterance(text);
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(utterance);
+    }
+  };
+
+  const Panel = ({ page, index }: { page: ComicPage; index: number }) => (
+    <div
+      className="relative cursor-pointer"
+      onClick={() => setActive(active === index ? null : index)}
+    >
+      <Image src={page.image} alt="Comic" width={800} height={1200} className="w-full h-auto" />
+      {active === index && (
+        <div className="absolute inset-0 bg-black/70 flex flex-col items-center justify-center text-white p-4 space-y-4">
+          <p className="text-center">{page.caption}</p>
+          <button
+            className="px-4 py-2 bg-white text-black rounded"
+            onClick={(e) => {
+              e.stopPropagation();
+              speak(page.caption);
+            }}
+          >
+            Escuchar
+          </button>
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex gap-2 justify-center">
+        <button
+          className={`px-4 py-2 rounded ${mode === 'vertical' ? 'bg-black text-white' : 'bg-gray-200'}`}
+          onClick={() => setMode('vertical')}
+        >
+          Vertical
+        </button>
+        <button
+          className={`px-4 py-2 rounded ${mode === 'panel' ? 'bg-black text-white' : 'bg-gray-200'}`}
+          onClick={() => setMode('panel')}
+        >
+          Viñeta por viñeta
+        </button>
+      </div>
+
+      {mode === 'vertical' ? (
+        <div className="space-y-6">
+          {pages.map((p, i) => (
+            <Panel key={i} page={p} index={i} />
+          ))}
+        </div>
+      ) : (
+        <Swiper spaceBetween={24} className="w-full" slidesPerView={1}>
+          {pages.map((p, i) => (
+            <SwiperSlide key={i}>
+              <Panel page={p} index={i} />
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      )}
+    </div>
+  );
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,18 +1,15 @@
-module.exports = {
+export default {
   root: true,
-  parser: "@typescript-eslint/parser",
-  parserOptions: { ecmaVersion: 2020, sourceType: "module" },
-  plugins: ["@typescript-eslint", "prettier"],
+  parser: '@typescript-eslint/parser',
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  plugins: ['@typescript-eslint', 'prettier'],
   extends: [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "next/core-web-vitals",
-    "plugin:prettier/recommended", // activa eslint-plugin-prettier y eslint-config-prettier
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'next/core-web-vitals',
+    'plugin:prettier/recommended',
   ],
   rules: {
-    // aquí tus overrides
-    "prettier/prettier": "error",
-    // p.ej. deshabilita reglas que te molesten:
-    // '@typescript-eslint/no-explicit-any': 'off',
+    'prettier/prettier': 'error',
   },
 };

--- a/pages/comic/index.tsx
+++ b/pages/comic/index.tsx
@@ -1,11 +1,11 @@
-﻿import SectionLayout from "@/components/SectionLayout";
+import SectionLayout from '@/components/SectionLayout';
+import ComicReader from '@/components/ui/ComicReader';
 
 export default function ComicPage() {
   return (
-    <SectionLayout title="Cómic">
-      <h1 className="text-2xl font-medium text-center">
-        Sumérgete en mi cuento gráfico…
-      </h1>
+    <SectionLayout title="Cómic" className="max-w-3xl mx-auto">
+      <h1 className="text-2xl font-medium text-center mb-8">Sumérgete en mi cuento gráfico…</h1>
+      <ComicReader />
     </SectionLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add new `ComicReader` component with vertical or panel-by-panel modes
- wire it into the Comic page
- adjust ESLint config to ES module format

## Testing
- `npm run lint` *(fails: Config (unnamed): Key "root" ...)*

------
https://chatgpt.com/codex/tasks/task_e_68402e1b8d38832e96b1d6dcc6f78b4e