### PR TITLE
Fix stray whitespace nodes in Spotify page

### DIFF
--- a/pages/music/spotify/index.tsx
+++ b/pages/music/spotify/index.tsx
@@ -16,7 +16,7 @@ const trackIds = [
 export default function SpotifyPage() {
   return (
     <>
-      {/* Declaramos la keyframes dentro de un style jsx global */}+{" "}
+      {/* Declaramos la keyframes dentro de un style jsx global */}
       <style jsx global>{`
         @keyframes pixel-pulse {
           0%,
@@ -117,8 +117,8 @@ export default function SpotifyPage() {
               frameBorder="0"
               allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
               loading="lazy"
-            ></iframe>{" "}
-          </div>{" "}
+            ></iframe>
+          </div>
         </div>
       </SectionLayout>
     </>


### PR DESCRIPTION
## Summary
- clean up `pages/music/spotify/index.tsx` by removing `{" "}` fragments
- ensure no extra text nodes are rendered

## Testing
- `npm run lint` *(fails: Config (unnamed): Key "root": This appears to be in eslintrc format rather than flat config format)*

------
https://chatgpt.com/codex/tasks/task_e_684034aec544832e956d8f1f62e8dad4