### PR TITLE
Enhance comic reader with zoom and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,10 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Comic Reader
+
+The comic section lets you switch between a vertical layout and a panel by panel reader. When viewing panels individually you can:
+
+- Zoom and pan over any panel using your mouse wheel or touch gestures.
+- Move through panels with the on-screen arrows or your keyboard arrow keys.

--- a/components/ui/ComicReader.tsx
+++ b/components/ui/ComicReader.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react';
 import Image from 'next/image';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import { Navigation, Keyboard } from 'swiper/modules';
+import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch';
 import 'swiper/css';
+import 'swiper/css/navigation';
 
 interface ComicPage {
   image: string;
@@ -44,7 +47,11 @@ export default function ComicReader() {
       className="relative cursor-pointer"
       onClick={() => setActive(active === index ? null : index)}
     >
-      <Image src={page.image} alt="Comic" width={800} height={1200} className="w-full h-auto" />
+      <TransformWrapper>
+        <TransformComponent>
+          <Image src={page.image} alt="Comic" width={800} height={1200} className="w-full h-auto" />
+        </TransformComponent>
+      </TransformWrapper>
       {active === index && (
         <div className="absolute inset-0 bg-black/70 flex flex-col items-center justify-center text-white p-4 space-y-4">
           <p className="text-center">{page.caption}</p>
@@ -86,7 +93,14 @@ export default function ComicReader() {
           ))}
         </div>
       ) : (
-        <Swiper spaceBetween={24} className="w-full" slidesPerView={1}>
+        <Swiper
+          spaceBetween={24}
+          className="w-full"
+          slidesPerView={1}
+          modules={[Navigation, Keyboard]}
+          navigation
+          keyboard
+        >
           {pages.map((p, i) => (
             <SwiperSlide key={i}>
               <Panel page={p} index={i} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "next": "15.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-zoom-pan-pinch": "^3.7.0",
         "rss-parser": "^3.13.0",
         "shadcn": "^2.5.0",
         "swiper": "^11.2.6",
@@ -7371,6 +7372,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz",
+      "integrity": "sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "next": "15.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-zoom-pan-pinch": "^3.7.0",
     "rss-parser": "^3.13.0",
     "shadcn": "^2.5.0",
     "swiper": "^11.2.6",


### PR DESCRIPTION
## Summary
- add `react-zoom-pan-pinch` dependency
- enable zoom and pan on comic images
- allow navigation and keyboard control in the panel viewer
- document comic reader usage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840381708a8832e90eb53f4b42f8a76