### PR TITLE
Fix ComicReader toolbar setup

### DIFF
--- a/components/ui/ComicReader.tsx
+++ b/components/ui/ComicReader.tsx
@@ -1,26 +1,21 @@
 import { Worker, Viewer, SpecialZoomLevel } from '@react-pdf-viewer/core';
-import { defaultLayoutPlugin, DefaultLayoutPlugin } from '@react-pdf-viewer/default-layout';
+import { defaultLayoutPlugin } from '@react-pdf-viewer/default-layout';
 import type { ToolbarProps, ToolbarSlot } from '@react-pdf-viewer/toolbar';
 import '@react-pdf-viewer/core/lib/styles/index.css';
 import '@react-pdf-viewer/default-layout/lib/styles/index.css';
-import { useMemo } from 'react';
 
 export default function ComicReader() {
-  const layoutPlugin = useMemo(() => {
-    // eslint-disable-next-line prefer-const
-    let plugin: DefaultLayoutPlugin;
-    const renderToolbar = (Toolbar: (props: ToolbarProps) => React.ReactElement) => (
+  const layoutPlugin = defaultLayoutPlugin({
+    renderToolbar: (Toolbar: (props: ToolbarProps) => React.ReactElement) => (
       <Toolbar>
-        {plugin.toolbarPluginInstance.renderDefaultToolbar((slots: ToolbarSlot) => ({
+        {layoutPlugin.toolbarPluginInstance.renderDefaultToolbar((slots: ToolbarSlot) => ({
           ...slots,
           Download: () => null,
           DownloadMenuItem: () => null,
         }))}
       </Toolbar>
-    );
-    plugin = defaultLayoutPlugin({ renderToolbar });
-    return plugin;
-  }, []);
+    ),
+  });
 
   return (
     <div className="relative mx-auto w-[150%] h-screen">


### PR DESCRIPTION
## Summary
- simplify ComicReader plugin initialization
- remove unused imports

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849763ef3a8832ea0b411c12fb8877e