### PR TITLE
Fix stray JSX fragment in Spotify page

### DIFF
--- a/pages/music/spotify/index.tsx
+++ b/pages/music/spotify/index.tsx
@@ -16,7 +16,7 @@ const trackIds = [
 export default function SpotifyPage() {
   return (
     <>
-      {/* Declaramos la keyframes dentro de un style jsx global */}+{' '}
+      {/* Declaramos la keyframes dentro de un style jsx global */}
       <style jsx global>{`
         @keyframes pixel-pulse {
           0%,


### PR DESCRIPTION
## Summary
- remove an unnecessary `{" "}` fragment after the global style comment in the Spotify page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849844bf7b8832ea505d00426f4f2ba