### PR TITLE
Fix plugin init ordering

### DIFF
--- a/components/ui/ComicReader.tsx
+++ b/components/ui/ComicReader.tsx
@@ -3,28 +3,32 @@ import { defaultLayoutPlugin, DefaultLayoutPlugin } from '@react-pdf-viewer/defa
 import type { ToolbarProps, ToolbarSlot } from '@react-pdf-viewer/toolbar';
 import '@react-pdf-viewer/core/lib/styles/index.css';
 import '@react-pdf-viewer/default-layout/lib/styles/index.css';
-import { useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 export default function ComicReader() {
-  const layoutPlugin = useMemo(() => {
-    // eslint-disable-next-line prefer-const
-    let plugin: DefaultLayoutPlugin;
-    const renderToolbar = (Toolbar: (props: ToolbarProps) => React.ReactElement) => (
+  const pluginRef = useRef<DefaultLayoutPlugin>();
+
+  const renderToolbar = useCallback(
+    (Toolbar: (props: ToolbarProps) => React.ReactElement) => (
       <Toolbar>
-        {plugin.toolbarPluginInstance.renderDefaultToolbar((slots: ToolbarSlot) => ({
+        {pluginRef.current?.toolbarPluginInstance.renderDefaultToolbar((slots: ToolbarSlot) => ({
           ...slots,
           Download: () => <></>,
           DownloadMenuItem: () => <></>,
         }))}
       </Toolbar>
-    );
-    plugin = defaultLayoutPlugin({ renderToolbar });
-    return plugin;
-  }, []);
+    ),
+    [],
+  );
+
+  const layoutPlugin = useMemo(() => {
+    const instance = defaultLayoutPlugin({ renderToolbar });
+    pluginRef.current = instance;
+    return instance;
+  }, [renderToolbar]);
 
   return (
     <div className="relative left-1/2 -translate-x-1/2 w-[150%] h-screen">
-
       <Worker workerUrl="/pdf.worker.js">
         <Viewer
           fileUrl="/Cuando los árboles dejaron de hablar_peq.pdf"


### PR DESCRIPTION
## Summary
- ensure the defaultLayoutPlugin instance is created before the toolbar tries to read it
- stabilize toolbar rendering logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849844d3e9c832ead4212d5ec5f2401