### PR TITLE
Fix lint warnings and restore assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 * text=auto
 *.pdf filter=lfs diff=lfs merge=lfs -text
-* text eol=lf

--- a/components/ui/ComicReader.tsx
+++ b/components/ui/ComicReader.tsx
@@ -65,7 +65,7 @@ export default function ComicReader() {
   /* ─── show/hide minigame ──────────────────────────────────────── */
   useEffect(() => {
     setMinigameVisible(currentPage === targetIndex && !minigameSolved);
-  }, [currentPage, minigameSolved]);
+  }, [currentPage, minigameSolved, targetIndex]);
 
   useEffect(() => {
     if (minigameVisible) lockScroll();

--- a/components/ui/GameFighter.tsx
+++ b/components/ui/GameFighter.tsx
@@ -81,4 +81,6 @@ const GameFighter = forwardRef<GameFighterHandle, Props>(
   },
 );
 
+GameFighter.displayName = "GameFighter";
+
 export default GameFighter;


### PR DESCRIPTION
## Summary
- restore previous `.gitattributes` to avoid corrupting binary files
- fix missing dependency warning in `ComicReader`
- add `displayName` for `GameFighter` and format with Prettier

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch YouTube RSS feed)*

------
https://chatgpt.com/codex/tasks/task_e_6852977b843c832e8cc5f5429862e0c2