### PR TITLE
Fix enemy AI cleanup

### DIFF
--- a/components/ui/ComicReader.tsx
+++ b/components/ui/ComicReader.tsx
@@ -40,7 +40,7 @@ export default function ComicReader() {
         Download: () => <></>,
         DownloadMenuItem: () => <></>,
       }),
-    []
+    [],
   );
 
   /* ─── freeze-scroll helpers ───────────────────────────────────── */
@@ -118,7 +118,7 @@ export default function ComicReader() {
           {layoutPlugin.current.toolbarPluginInstance && (
             <layoutPlugin.current.toolbarPluginInstance.Toolbar>
               {layoutPlugin.current.toolbarPluginInstance.renderDefaultToolbar(
-                transform
+                transform,
               )}
             </layoutPlugin.current.toolbarPluginInstance.Toolbar>
           )}

--- a/components/ui/GameFighter.tsx
+++ b/components/ui/GameFighter.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { forwardRef, useImperativeHandle, useEffect, useRef } from "react";
+import RoundManager from "game-fighter/src/game/RoundManager";
 import Phaser from "phaser";
 
 import BootScene from "game-fighter/src/scenes/BootScene";
@@ -65,7 +66,8 @@ const GameFighter = forwardRef<GameFighterHandle, Props>(
 
       /* limpieza segura */
       return () => {
-        setTimeout(() => gameRef.current?.destroy(true), 0);
+        RoundManager.stopEnemyAI();
+        gameRef.current?.destroy(true);
       };
     }, [onSolved]);
 

--- a/game-fighter/src/game/RoundManager.ts
+++ b/game-fighter/src/game/RoundManager.ts
@@ -41,9 +41,9 @@ export default class RoundManager {
   }
 
   static stopEnemyAI() {
-    if (this.aiTimer) {
+    if (this.aiTimer !== null) {
       clearInterval(this.aiTimer);
-      this.aiTimer = null;
     }
+    this.aiTimer = null;
   }
 }

--- a/game-fighter/src/scenes/FightScene.ts
+++ b/game-fighter/src/scenes/FightScene.ts
@@ -44,7 +44,14 @@ export default class FightScene extends Phaser.Scene {
     // Inicia la banda sonora 8‑bit en bucle
     this.bgm = this.sound.add("bgm", { loop: true, volume: 0.5 });
     this.bgm.play();
-    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => this.bgm.stop());
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      this.bgm.stop();
+      RoundManager.stopEnemyAI();
+    });
+    this.events.once(
+      Phaser.Scenes.Events.DESTROY,
+      RoundManager.stopEnemyAI,
+    );
 
     // 1️⃣ — Fondo y plataformas
     this.add
@@ -82,6 +89,7 @@ export default class FightScene extends Phaser.Scene {
     this.enemy.setFlipX(true);
 
     this.physics.add.collider(this.enemy, platforms);
+    RoundManager.startEnemyAI(this.player, this.enemy);
 
     // 6️⃣ — Overlap: cualquier HitBox del grupo golpea al enemigo
     this.physics.add.overlap(this.hitGroup, this.enemy, (objA, objB) => {
@@ -153,24 +161,7 @@ export default class FightScene extends Phaser.Scene {
       );
       this.playerHealthText.setText(`${hp}`);
       if (hp <= 0 && !this.ended) {
-        this.ended = true;
-        this.canMove = false;
-        this.add
-          .text(400, 300, "You Lose", {
-            fontSize: "32px",
-            color: "#ffffff",
-          })
-          .setOrigin(0.5);
-        RoundManager.enemyWins += 1;
-        const next = () => {
-          if (RoundManager.hasPlayerLost()) {
-            this.scene.start("GameOverScene");
-          } else {
-            RoundManager.nextRound();
-            this.scene.restart();
-          }
-        };
-        this.time.delayedCall(2000, next);
+        this.handleLose();
       }
     });
     this.enemy.on("healthChanged", (hp: number) => {
@@ -183,24 +174,7 @@ export default class FightScene extends Phaser.Scene {
       );
       this.enemyHealthText.setText(`${hp}`);
       if (hp <= 0 && !this.ended) {
-        this.ended = true;
-        this.canMove = false;
-        this.add
-          .text(400, 300, "You Win", {
-            fontSize: "32px",
-            color: "#ffffff",
-          })
-          .setOrigin(0.5);
-        RoundManager.playerWins += 1;
-        const next = () => {
-          if (RoundManager.hasPlayerWon()) {
-            this.scene.start("VictoryScene");
-          } else {
-            RoundManager.nextRound();
-            this.scene.restart();
-          }
-        };
-        this.time.delayedCall(2000, next);
+        this.handleWin();
       }
     });
 
@@ -271,6 +245,50 @@ export default class FightScene extends Phaser.Scene {
     if (!this.canMove) return;
     this.player.update(time, delta);
     (this.enemy as Enemy).update(time, delta);
+  }
+
+  private handleWin() {
+    this.ended = true;
+    this.canMove = false;
+    RoundManager.stopEnemyAI();
+    this.add
+      .text(400, 300, "You Win", {
+        fontSize: "32px",
+        color: "#ffffff",
+      })
+      .setOrigin(0.5);
+    RoundManager.playerWins += 1;
+    const next = () => {
+      if (RoundManager.hasPlayerWon()) {
+        this.scene.start("VictoryScene");
+      } else {
+        RoundManager.nextRound();
+        this.scene.restart();
+      }
+    };
+    this.time.delayedCall(2000, next);
+  }
+
+  private handleLose() {
+    this.ended = true;
+    this.canMove = false;
+    RoundManager.stopEnemyAI();
+    this.add
+      .text(400, 300, "You Lose", {
+        fontSize: "32px",
+        color: "#ffffff",
+      })
+      .setOrigin(0.5);
+    RoundManager.enemyWins += 1;
+    const next = () => {
+      if (RoundManager.hasPlayerLost()) {
+        this.scene.start("GameOverScene");
+      } else {
+        RoundManager.nextRound();
+        this.scene.restart();
+      }
+    };
+    this.time.delayedCall(2000, next);
   }
 
   private playHitEffects(hit: HitBox) {

--- a/mi-portfolio/components/ui/game-fighter/game/Enemy.ts
+++ b/mi-portfolio/components/ui/game-fighter/game/Enemy.ts
@@ -520,6 +520,10 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
     }
   }
 
+  public do(action: EnemyDecision) {
+    this.pendingDecision = action;
+  }
+
   /** ========================================
    *  ③ Método estático para crear animaciones
    *  ========================================

--- a/mi-portfolio/components/ui/game-fighter/game/RoundManager.ts
+++ b/mi-portfolio/components/ui/game-fighter/game/RoundManager.ts
@@ -1,3 +1,7 @@
+import { requestEnemyAction } from "./EnemyAI";
+import { Player } from "./Player";
+import { Enemy } from "./Enemy";
+
 export default class RoundManager {
   static playerWins = 0;
   static enemyWins = 0;
@@ -11,6 +15,26 @@ export default class RoundManager {
 
   static nextRound() {
     this.round += 1;
+  }
+
+  /* ---------- IA enemigo ---------- */
+  private static aiTimer: ReturnType<typeof setInterval> | null = null;
+
+  static startEnemyAI(player: Player, enemy: Enemy) {
+    if (this.aiTimer) return;
+    this.aiTimer = setInterval(async () => {
+      const action = await requestEnemyAction({
+        distance: Math.abs(player.x - enemy.x),
+      });
+      if (action) enemy.do(action);
+    }, 200);
+  }
+
+  static stopEnemyAI() {
+    if (this.aiTimer !== null) {
+      clearInterval(this.aiTimer);
+    }
+    this.aiTimer = null;
   }
 
   static hasPlayerLost() {


### PR DESCRIPTION
## Summary
- start enemy AI cleanup when React unmounts
- stop AI timer when the scene is destroyed
- make `stopEnemyAI` always clear the timer

## Testing
- `npm run lint`
- `npm run test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6852ab45d7ec832e90f721c6d7bfade2