### PR TITLE
Add avatar walk animation

### DIFF
--- a/game-fighter/src/game/Player.ts
+++ b/game-fighter/src/game/Player.ts
@@ -36,6 +36,9 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
     scene.add.existing(this);
     scene.physics.add.existing(this);
 
+    Player.createAnimations(scene.anims);
+    this.play("player_walk");
+
     this.setCollideWorldBounds(true);
     (this.body as Phaser.Physics.Arcade.Body).setGravityY(980);
 
@@ -311,5 +314,18 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
     this.isGuarding = false;
     this.guardState = "none";
     this.anims.play("player_idle", true);
+  }
+
+  /**
+   * Crea la animación de caminar si aún no existe.
+   */
+  public static createAnimations(anims: Phaser.Animations.AnimationManager) {
+    if (anims.exists("player_walk")) return;
+    anims.create({
+      key: "player_walk",
+      frames: anims.generateFrameNumbers("player_walk", { start: 0, end: 5 }),
+      frameRate: 8,
+      repeat: -1,
+    });
   }
 }

--- a/game-fighter/src/scenes/PreloadScene.ts
+++ b/game-fighter/src/scenes/PreloadScene.ts
@@ -37,6 +37,12 @@ export default class PreloadScene extends Phaser.Scene {
 
     this.tryLoadSprite("player_ko", `${P}young_ko.png`, 64, 48); // por ejemplo: 64 de ancho
 
+    /* ╔═════════════ AVATAR (32×32) ═════════════╗ */
+    this.load.spritesheet("player_walk", "/sprites/avatar-walk.png", {
+      frameWidth: 32,
+      frameHeight: 32,
+    });
+
     /* ╔═════════════ DETECTIVE / ENEMY (48×64) ═════════════╗ */
     const D = "assets/detective/";
     const d = (key: string, file: string) =>


### PR DESCRIPTION
## Summary
- load avatar walk spritesheet
- create `player_walk` animation and play it by default
- remove placeholder sprite sheet from repo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853d4f77df8832e81b405e2ded83393