### PR TITLE
Add shared avatar loader

### DIFF
--- a/game-fighter/src/scenes/PreloadScene.ts
+++ b/game-fighter/src/scenes/PreloadScene.ts
@@ -1,6 +1,7 @@
 // game-fighter/src/scenes/PreloadScene.ts
 import Phaser from "phaser";
 import RoundManager from "../game/RoundManager";
+import { loadSharedAssets, createSharedAnimations } from "../utils/SharedLoader";
 
 /* Helper – mapea a /public/game-fighter/... */
 const asset = (f: string) => `/game-fighter/${f}`;
@@ -17,6 +18,8 @@ export default class PreloadScene extends Phaser.Scene {
     this.tryLoadAudio("bgm", ["audio/bgm.ogg", "audio/bgm.mp3"]);
     this.tryLoadAudio("hit_sound", ["audio/hit.ogg", "audio/hit.mp3"]);
     this.tryLoadAudio("coin_sound", ["audio/coin.wav"]); // ahora protegido
+
+    loadSharedAssets(this);
 
     // ╔═════════════ PLAYER (48×48) ═════════════╗
     const P = "assets/young/";
@@ -36,6 +39,7 @@ export default class PreloadScene extends Phaser.Scene {
     ].forEach((action) => p(`player_${action}`));
 
     this.tryLoadSprite("player_ko", `${P}young_ko.png`, 64, 48); // por ejemplo: 64 de ancho
+
 
     /* ╔═════════════ DETECTIVE / ENEMY (48×64) ═════════════╗ */
     const D = "assets/detective/";
@@ -81,6 +85,7 @@ export default class PreloadScene extends Phaser.Scene {
 
   create() {
     RoundManager.reset();
+    createSharedAnimations(this);
 
     const prompt = this.add
       .text(400, 320, "Pulsa para empezar", {

--- a/game-fighter/src/utils/SharedLoader.ts
+++ b/game-fighter/src/utils/SharedLoader.ts
@@ -1,0 +1,40 @@
+import Phaser from "phaser";
+
+export function loadSharedAssets(scene: Phaser.Scene) {
+  // Walk
+  scene.load.spritesheet("avatar_walk_sheet", "/sprites/avatar.png", {
+    frameWidth: 32,
+    frameHeight: 32,
+  });
+  // Idle
+  scene.load.spritesheet("avatar_idle_sheet", "/sprites/avatar-idle.png", {
+    frameWidth: 32,
+    frameHeight: 32,
+  });
+}
+
+export function createSharedAnimations(scene: Phaser.Scene) {
+  if (!scene.anims.exists("avatar_walk")) {
+    scene.anims.create({
+      key: "avatar_walk",
+      frames: scene.anims.generateFrameNumbers("avatar_walk_sheet", {
+        start: 0,
+        end: 3,
+      }),
+      frameRate: 8,
+      repeat: -1,
+    });
+  }
+
+  if (!scene.anims.exists("avatar_idle")) {
+    scene.anims.create({
+      key: "avatar_idle",
+      frames: scene.anims.generateFrameNumbers("avatar_idle_sheet", {
+        start: 0,
+        end: 1,
+      }),
+      frameRate: 2,
+      repeat: -1,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- centralize avatar spritesheets and animations in `SharedLoader`
- preload shared assets and set up animations in `PreloadScene`
- use existing `/sprites/avatar.png` (4 frames) instead of placeholder and remove generated sprite

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853d4f77df8832e81b405e2ded83393