### PR TITLE
Improve responsive layout for mobile

### DIFF
--- a/components/BigTitle.tsx
+++ b/components/BigTitle.tsx
@@ -1,6 +1,6 @@
 // components/BigTitle.tsx
 export interface BigTitleProps {
-  titleSize?: string; // cualquier unidad CSS válida, ej. "4rem", "10vw", "clamp(3rem,12vw,8rem)"
+  titleSize?: string; // tamaño de letra en escritorio
   paragraphSize?: string;
 }
 
@@ -9,26 +9,22 @@ export default function BigTitle({
   paragraphSize = "clamp(1rem,4vw,2rem)",
 }: BigTitleProps) {
   return (
-    <section className="py-24 bg-white text-black">
-      <div className="w-full mx-auto px-4 text-center">
+    <section className="bg-white text-black py-16 lg:py-24">
+      <div className="w-full max-w-4xl mx-auto px-4 sm:px-8 text-center">
         <h1
-          style={{
-            fontSize: titleSize,
-            textAlign: "justify",
-            textAlignLast: "justify",
-          }}
-          className="font-notable uppercase tracking-widest leading-none"
+          style={
+            {
+              // tamaño original para escritorio
+              "--title-lg": titleSize,
+            } as React.CSSProperties
+          }
+          className="font-notable uppercase tracking-widest leading-none text-4xl sm:text-6xl lg:text-[var(--title-lg)] text-justify"
         >
           Bienvenido a mi sitio
         </h1>
         <p
-          style={{
-            fontSize: paragraphSize,
-            marginTop: "25px",
-            textAlign: "justify", // justifica cada línea
-            textAlignLast: "justify", // también justifica la última línea
-          }}
-          className="w-full leading-snug text-justify"
+          style={{ "--paragraph-lg": paragraphSize } as React.CSSProperties}
+          className="mt-6 w-full leading-snug text-base sm:text-lg lg:text-[var(--paragraph-lg)] text-justify"
         >
           Un cuento gráfico sobre la relación entre humanos y el silencio de
           los&nbsp;árboles.

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -22,7 +22,7 @@ export default function Nav() {
 
   return (
     <header className="sticky top-0 inset-x-0 z-50 bg-white/80 backdrop-blur-md shadow-sm">
-      <nav className="relative inset-x-0 top-0 bg-white/75 backdrop-blur-md shadow-sm">
+      <nav className="relative inset-x-0 top-0 bg-white/75 backdrop-blur-md shadow-sm flex items-center justify-between w-full px-4 sm:px-8 lg:px-16 max-w-4xl mx-auto">
         {/* --- Logo --- */}
         <div className="flex items-center space-x-2 flex-shrink-0">
           <Image src="/logo.svg" alt="Logo" width={40} height={40} priority />

--- a/components/SectionLayout.tsx
+++ b/components/SectionLayout.tsx
@@ -16,7 +16,10 @@ export default function SectionLayout({
   ...rest
 }: SectionLayoutProps) {
   return (
-    <section className={`relative z-10 py-16 px-4 ${className}`} {...rest}>
+    <section
+      className={`relative z-10 py-16 w-full px-4 sm:px-8 lg:px-16 max-w-4xl mx-auto ${className}`}
+      {...rest}
+    >
       {title && (
         <h2 className="text-4xl font-serif font-bold text-center mb-8">
           {title}

--- a/components/ui/HeroCarousel.tsx
+++ b/components/ui/HeroCarousel.tsx
@@ -16,7 +16,7 @@ export default function HeroCarousel() {
   ];
 
   return (
-    <section className="relative w-full h-screen md:h-[90vh]">
+    <section className="relative w-full h-[70vh] sm:h-screen md:h-[90vh]">
       {/* Carrusel */}
       <Swiper
         modules={[Autoplay, Navigation, Pagination]}


### PR DESCRIPTION
## Summary
- adjust SectionLayout container for consistency
- reduce hero height on small screens
- update BigTitle fonts for mobile breakpoints
- center navigation content

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853eb885564832ebcf88ebca4468a99