### PR TITLE
Mejorar grid y ancho de contenido

### DIFF
--- a/components/SectionLayout.tsx
+++ b/components/SectionLayout.tsx
@@ -19,18 +19,16 @@ export default function SectionLayout({
   return (
     <section
       className={cn(
-        'w-full',
-        'px-4 md:px-8 xl:px-12',
-        'py-8',
+        'w-full max-w-none',
         'mx-auto',
+        'px-4 sm:px-8 xl:px-12',
+        'py-8 sm:py-12',
         className,
       )}
       {...rest}
     >
       {title && (
-        <h2 className="text-4xl font-serif font-bold text-center mb-8">
-          {title}
-        </h2>
+        <h1 className="text-3xl font-bold mb-8 text-center">{title}</h1>
       )}
       {children}
     </section>

--- a/components/VideoGrid.tsx
+++ b/components/VideoGrid.tsx
@@ -8,20 +8,22 @@ interface Props {
 
 export default function VideoGrid({ videos }: Props) {
   return (
-    <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       {videos.map((id) => (
         <div
           key={id}
-          className="w-full overflow-hidden rounded-lg border border-neutral-700"
+          className="relative aspect-video w-full overflow-hidden rounded-lg border border-neutral-700"
         >
-          {/* 16:9 aspect-ratio wrapper */}
-          <div className="relative pb-[56.25%]">
-            <YouTube
-              videoId={id}
-              iframeClassName="absolute inset-0 w-full h-full"
-              opts={{ playerVars: { playsinline: 1 } }}
-            />
-          </div>
+          <YouTube
+            videoId={id}
+            className="absolute inset-0 w-full h-full"
+            iframeClassName="w-full h-full"
+            opts={{
+              width: '100%',
+              height: '100%',
+              playerVars: { playsinline: 1 },
+            }}
+          />
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- establecer ancho completo y padding responsive en las secciones
- mostrar miniaturas de YouTube a 16:9 y ajustar grilla responsive

## Testing
- `npm run lint` *(fails: many prettier errors in repo)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685911cf811c832eb259d057fd5eb470