### PR TITLE
feat(avatar): mount AvatarGuide globally & add sprite-sheet styles

### DIFF
--- a/components/AvatarGuide.tsx
+++ b/components/AvatarGuide.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
-import Image from 'next/image';
+import { useEffect, useRef } from 'react';
 
 const ANIMS = {
   walk: { sheet: '/sprites/avatar-walk.png', frames: 6 },
@@ -9,18 +8,20 @@ const ANIMS = {
 
 export default function AvatarGuide() {
   const ref = useRef<HTMLDivElement>(null);
-  const [state, setState] = useState<'walk' | 'idle'>('idle');
 
   /* helper para iniciar animación sprite-sheet via CSS */
   const setAnim = (name: 'walk' | 'idle') => {
-    const { frames } = ANIMS[name];
+    const { sheet, frames } = ANIMS[name];
+    ref.current!.style.setProperty('--sheet', `url("${sheet}")`);
     ref.current!.style.setProperty('--frames', String(frames));
     ref.current!.style.setProperty('--anim-name', name);
-    setState(name);
   };
 
   useEffect(() => {
     /* On mount: listen scroll & nav clicks */
+    if (ref.current) {
+      ref.current.style.setProperty('--sheet', `url("${ANIMS.idle.sheet}")`);
+    }
     const scroll = () => {
       /* calcula sección más visible, mueve avatar */
     };
@@ -52,10 +53,8 @@ export default function AvatarGuide() {
     <div
       ref={ref}
       aria-hidden
-      className="fixed left-4 bottom-4 z-[9999] w-12 h-12 pointer-events-none
-                 bg-[image:var(--sheet,url('/sprites/avatar-idle.png'))]
-                 animate-[var(--anim-name,idle)_steps(var(--frames))_0.8s_infinite]"
-      style={{ '--frames': 4, '--anim-name': 'idle' } as any}
+      className="avatar-guide"
+      style={{ '--frames': 4, '--anim-name': 'idle' } as React.CSSProperties}
     />
   );
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,9 +1,10 @@
 // pages/_app.tsx
 import '../styles/globals.css';
+import '../styles/avatar-guide.css';
 import type { AppProps } from 'next/app';
 import Nav from '../components/Nav';
 import Footer from '../components/Footer';
-import AvatarGuide from '../components/AvatarGuide';
+import AvatarGuide from '@/components/AvatarGuide';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
@@ -15,7 +16,9 @@ export default function App({ Component, pageProps }: AppProps) {
         </main>
         <Footer />
       </div>
-      <AvatarGuide />
+      <div className="fixed bottom-4 left-4 z-[9999]">
+        <AvatarGuide />
+      </div>
     </>
   );
 }

--- a/styles/avatar-guide.css
+++ b/styles/avatar-guide.css
@@ -1,0 +1,23 @@
+.avatar-guide {
+  width: 32px;
+  height: 32px;
+  background-image: var(--sheet);
+  background-size: auto 100%;
+  animation: var(--anim-name) 0.8s steps(var(--frames)) infinite;
+}
+@keyframes idle {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: -128px 0;
+  }
+}
+@keyframes walk {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: -192px 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add shared sprite sheet styles
- mount `AvatarGuide` globally in `_app.tsx`
- update `AvatarGuide` to use new CSS variables

## Testing
- `npm run lint`
- `npm run dev` *(fails: Next.js dev server started)*

------
https://chatgpt.com/codex/tasks/task_e_68591ceeb424832ebc5cff5afbd81190