### PR TITLE
Fix AvatarGuide overlay and hide dev icon

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,14 +10,14 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <Nav />
+      <div className="fixed bottom-4 right-4 z-[9999] pointer-events-none">
+        <AvatarGuide />
+      </div>
       <div className="pt-16 w-full">
         <main className="w-full flex flex-col flex-1">
           <Component {...pageProps} />
         </main>
         <Footer />
-      </div>
-      <div className="fixed bottom-4 left-4 z-[9999]">
-        <AvatarGuide />
       </div>
     </>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -250,3 +250,8 @@
   background-image: var(--sheet);
   animation: var(--anim-name) steps(var(--frames)) 0.8s infinite;
 }
+
+/* Oculta el círculo negro con la N que genera Next.js en modo dev */
+nextjs-portal {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- position `AvatarGuide` at bottom-right and ensure it mounts once
- hide the development overlay circle with `N`

## Testing
- `npm test` *(fails: No tests specified)*
- `npx vitest run` *(fails: needs network for vitest package)*
- `npx jest` *(fails: needs network for jest package)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592a21d2a8832e995d9d01b48f5621