### PR TITLE
Update AvatarGuide animation

### DIFF
--- a/__tests__/AvatarGuide.test.tsx
+++ b/__tests__/AvatarGuide.test.tsx
@@ -1,8 +1,10 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import AvatarGuide from '../components/AvatarGuide';
 
-test('renders AvatarGuide with idle state', () => {
+test('renders AvatarGuide with idle state', async () => {
   const { container } = render(<AvatarGuide />);
-  const div = container.querySelector('div');
-  expect(div).toHaveStyle('--anim-name: idle');
+  const div = container.querySelector('div') as HTMLDivElement;
+  await waitFor(() => {
+    expect(div.style.getPropertyValue('--sheet')).toBe('url("/sprites/avatar-idle.png")');
+  });
 });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,9 +10,7 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <Nav />
-      <div className="fixed bottom-4 right-4 z-[9999] pointer-events-none">
-        <AvatarGuide />
-      </div>
+      <AvatarGuide />
       <div className="pt-16 w-full">
         <main className="w-full flex flex-col flex-1">
           <Component {...pageProps} />

--- a/styles/avatar-guide.css
+++ b/styles/avatar-guide.css
@@ -1,23 +1,16 @@
-.avatar-guide {
-  width: 32px;
-  height: 32px;
+.animate-avatar {
   background-image: var(--sheet);
   background-size: auto 100%;
-  animation: var(--anim-name) 0.8s steps(var(--frames)) infinite;
+  width: var(--w);
+  height: var(--h);
+  animation: avatar var(--dur) steps(var(--frames)) infinite;
 }
-@keyframes idle {
+
+@keyframes avatar {
   from {
-    background-position: 0 0;
+    background-position-x: 0;
   }
   to {
-    background-position: -128px 0;
-  }
-}
-@keyframes walk {
-  from {
-    background-position: 0 0;
-  }
-  to {
-    background-position: -192px 0;
+    background-position-x: calc(var(--w) * var(--frames) * -1);
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,10 @@ module.exports = {
         sans: ['Inter', 'sans-serif'],
       },
       keyframes: {
+        avatar: {
+          '0%': { backgroundPositionX: '0' },
+          '100%': { backgroundPositionX: 'calc(var(--w) * var(--frames) * -1)' },
+        },
         'ghost-move': {
           '0%': { transform: 'translateX(-100%)' },
           '100%': { transform: 'translateX(100vw)' },
@@ -20,6 +24,7 @@ module.exports = {
       },
       animation: {
         ghost: 'ghost-move 8s linear infinite',
+        avatar: 'avatar var(--dur) steps(var(--frames)) infinite',
       },
     },
   },


### PR DESCRIPTION
## Summary
- overhaul `AvatarGuide` to use sprite metadata with CSS variables
- animate avatar via new `animate-avatar` utility
- remove wrapper in `_app.tsx`
- update Tailwind config with `avatar` keyframes
- adjust test for new style

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68592cfaa3dc832e89334cbe033dda1c