### PR TITLE
Update AvatarGuide sprite handling

### DIFF
--- a/__tests__/AvatarGuide.test.tsx
+++ b/__tests__/AvatarGuide.test.tsx
@@ -1,8 +1,10 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import AvatarGuide from '../components/AvatarGuide';
 
-test('renders AvatarGuide with idle state', () => {
+test('renders AvatarGuide with idle state', async () => {
   const { container } = render(<AvatarGuide />);
-  const div = container.querySelector('div');
-  expect(div).toHaveStyle('--anim-name: idle');
+  const div = container.querySelector('div') as HTMLDivElement;
+  await waitFor(() => {
+    expect(div.style.getPropertyValue('--sheet')).toBe('url("/sprites/avatar-idle.png")');
+  });
 });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,9 +10,7 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <Nav />
-      <div className="fixed bottom-4 right-4 z-[9999] pointer-events-none">
-        <AvatarGuide />
-      </div>
+      <AvatarGuide />
       <div className="pt-16 w-full">
         <main className="w-full flex flex-col flex-1">
           <Component {...pageProps} />

--- a/styles/avatar-guide.css
+++ b/styles/avatar-guide.css
@@ -1,23 +1,24 @@
 .avatar-guide {
-  width: 32px;
-  height: 32px;
-  background-image: var(--sheet);
-  background-size: auto 100%;
-  animation: var(--anim-name) 0.8s steps(var(--frames)) infinite;
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  width: calc(var(--frame-w) * 0.75);
+  height: calc(var(--frame-h) * 0.75);
+  background: url(var(--sheet)) no-repeat 0 0 / auto 100%;
+  animation: var(--anim-name) steps(var(--frames)) 1s infinite;
+  image-rendering: pixelated;
+  pointer-events: none;
+  z-index: 9999;
 }
+
 @keyframes idle {
-  from {
-    background-position: 0 0;
-  }
   to {
-    background-position: -128px 0;
+    background-position-x: -200%;
   }
 }
+
 @keyframes walk {
-  from {
-    background-position: 0 0;
-  }
   to {
-    background-position: -192px 0;
+    background-position-x: -300%;
   }
 }


### PR DESCRIPTION
## Summary
- redo avatar constants to use 176x377 sprite size metadata
- revise AvatarGuide component with id check and CSS variables
- rework global avatar-guide styles
- drop unused avatar animation in tailwind config

## Testing
- `npx vitest run`
- `npm run dev` *(manual check)*

------
https://chatgpt.com/codex/tasks/task_e_68592cfaa3dc832e89334cbe033dda1c