### PR TITLE
Refactor avatar guide effect

### DIFF
--- a/components/AvatarGuide.tsx
+++ b/components/AvatarGuide.tsx
@@ -4,8 +4,6 @@ import { createRoot } from 'react-dom/client';
 import idleSheet from '@/public/sprites/avatar-idle.png';
 import walkSheet from '@/public/sprites/avatar-walk.png';
 
-const FRAME_W = idleSheet.width / 2; // 2 frames en idle (png = 2 columnas)
-const FRAME_H = idleSheet.height;
 const SHEET = { idle: idleSheet.src, walk: walkSheet.src } as const;
 const FRAMES = { idle: 2, walk: 6 } as const;
 const ROOT_ID = 'avatar-guide-root';
@@ -13,7 +11,8 @@ const ROOT_ID = 'avatar-guide-root';
 export default function AvatarGuide() {
   const ref = useRef<HTMLElement>(null);
   const [state, setState] = useState<'idle' | 'walk'>('idle');
-  
+  const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
+
   // ensure a single guide instance mounted in the page
   useEffect(() => {
     const already = document.getElementById(ROOT_ID);
@@ -27,21 +26,32 @@ export default function AvatarGuide() {
   const rootExists =
     typeof window !== 'undefined' && document.getElementById(ROOT_ID);
 
-  // inicializa variables de tamaño al montar
   useEffect(() => {
     if (!rootExists || !ref.current) return;
-    ref.current.style.setProperty('--frame-w', `${FRAME_W}px`);
-    ref.current.style.setProperty('--frame-h', `${FRAME_H}px`);
-  }, [rootExists]);
+    const el = ref.current;
 
-  // aplica animación y sprite en cada cambio de estado
-  useEffect(() => {
-    if (!rootExists || !ref.current) return;
+    const updateStyles = (w: number, h: number) => {
+      el.style.setProperty('--frame-w', `${w}px`);
+      el.style.setProperty('--frame-h', `${h}px`);
+    };
+
+    if (!dims) {
+      const img = new Image();
+      img.src = idleSheet.src;
+      const decode = img.decode ? img.decode() : Promise.reject();
+      decode
+        .then(() => setDims({ w: img.width / FRAMES.idle, h: img.height }))
+        .catch(() => setDims({ w: 176, h: 377 }));
+      return;
+    }
+
+    updateStyles(dims.w, dims.h);
     const frames = FRAMES[state];
-    ref.current.style.setProperty('--frames', String(frames));
-    ref.current.style.setProperty('--anim-name', state);
-    ref.current.style.backgroundImage = `url(${SHEET[state]})`;
-  }, [state, rootExists]);
+    el.style.setProperty('--frames', String(frames));
+    el.style.setProperty('--shift', `calc(var(--frame-w) * -${frames})`);
+    el.style.backgroundImage = `url(${SHEET[state]})`;
+    el.style.animationName = 'avatar-animate';
+  }, [rootExists, state, dims]);
 
   // detecta scroll para cambiar temporalmente a 'walk'
   useEffect(() => {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -196,40 +196,10 @@
     background-size: 100% 4px;
   }
 }
-@keyframes flicker {
-  0%,
-  100% {
-    opacity: 0.95;
-  }
-  5% {
-    opacity: 0.85;
-  }
-  10% {
-    opacity: 0.9;
-  }
-}
 
-.crt-effect {
-  @apply border-4 border-red-700/50;
-  animation: flicker 0.15s infinite;
-}
-
-.scanlines {
-  background-image: linear-gradient(
-    rgba(255, 255, 255, 0.02) 1px,
-    transparent 1px
-  );
-  background-size: 100% 4px;
-}
-@keyframes idle {
+@keyframes avatar-animate {
   to {
-    background-position-x: calc(var(--frame-w) * -2);
-  }
-}
-
-@keyframes walk {
-  to {
-    background-position-x: calc(var(--frame-w) * -6);
+    background-position-x: var(--shift);
   }
 }
 
@@ -238,11 +208,11 @@
   bottom: 2rem;
   right: 2rem;
   z-index: 50;
-  width: calc(var(--frame-w) * 0.75);
-  height: calc(var(--frame-h) * 0.75);
+  width: calc(var(--frame-w) * 0.25);
+  height: calc(var(--frame-h) * 0.25);
   background: url('/sprites/avatar-idle.png') left bottom/auto;
   image-rendering: pixelated;
-  animation: var(--anim-name) steps(var(--frames)) 0.8s infinite;
+  animation: avatar-animate 0.8s steps(var(--frames)) infinite;
   pointer-events: none;
   filter: drop-shadow(0 0 3px #0008);
   transform-origin: bottom right;


### PR DESCRIPTION
## Summary
- avoid recomputing sprite dimensions on every scroll
- keep only one avatar animation keyframe and remove duplicate styles

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685975844f7c832e846ea223bdb84986