### PR TITLE
Add Arkanoid page with dynamic import

### DIFF
--- a/components/ui/game-arkanoid/Arkanoid.tsx
+++ b/components/ui/game-arkanoid/Arkanoid.tsx
@@ -1,0 +1,10 @@
+// components/ui/game-arkanoid/Arkanoid.tsx
+'use client';
+
+export default function Arkanoid() {
+  return (
+    <div className="flex items-center justify-center h-64 bg-black text-white">
+      Arkanoid game placeholder
+    </div>
+  );
+}

--- a/pages/videos/arkanoid.tsx
+++ b/pages/videos/arkanoid.tsx
@@ -1,0 +1,16 @@
+// pages/videos/arkanoid.tsx
+import dynamic from 'next/dynamic';
+
+const Arkanoid = dynamic(
+  () => import('@/components/ui/game-arkanoid/Arkanoid'),
+  { ssr: false },
+);
+
+export default function ArkanoidPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Arkanoid</h1>
+      <Arkanoid />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Arkanoid component placeholder
- add `/videos/arkanoid` page that loads the Arkanoid game dynamically

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685a84291354832e89308b42a7ea9fb7