### PR TITLE
Add full-screen Arkanoid overlay

### DIFF
--- a/components/ui/game-arkanoid/Arkanoid.tsx
+++ b/components/ui/game-arkanoid/Arkanoid.tsx
@@ -3,18 +3,10 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-export interface ArkanoidProps {
-  /** Whether the game should run */
-  isActive: boolean;
-  /** Identifier used to reset the game when the active video changes */
-  videoId: string;
-}
-
 /**
  * Minimal Arkanoid canvas prepared for future logic.
- * When `isActive` is false a simple placeholder is rendered.
  */
-export default function Arkanoid({ isActive, videoId }: ArkanoidProps) {
+export default function Arkanoid() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [leftPressed, setLeftPressed] = useState(false);
@@ -25,7 +17,6 @@ export default function Arkanoid({ isActive, videoId }: ArkanoidProps) {
   void rightPressed;
 
   useEffect(() => {
-    if (!isActive) return;
 
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -63,11 +54,7 @@ export default function Arkanoid({ isActive, videoId }: ArkanoidProps) {
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
     };
-  }, [isActive, videoId]);
-
-  if (!isActive) {
-    return <div className="w-full h-full bg-gray-800" />;
-  }
+  }, []);
 
   return (
     <div ref={containerRef} className="w-full h-full">

--- a/components/ui/game-arkanoid/ArkanoidOverlay.tsx
+++ b/components/ui/game-arkanoid/ArkanoidOverlay.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface Props {
+  onClose: () => void;
+}
+
+interface Block {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  alive: boolean;
+}
+
+export default function ArkanoidOverlay({ onClose }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const resize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    };
+    resize();
+    window.addEventListener('resize', resize);
+
+    let paddleX = canvas.width / 2 - 40;
+    const paddleWidth = 80;
+    const paddleHeight = 10;
+    let leftPressed = false;
+    let rightPressed = false;
+
+    const ball = { x: canvas.width / 2, y: canvas.height / 2, r: 6, dx: 2, dy: -2 };
+
+    const blocks: Block[] = [];
+    const cols = 8;
+    const rows = 4;
+    const bw = 60;
+    const bh = 20;
+    for (let c = 0; c < cols; c++) {
+      for (let r = 0; r < rows; r++) {
+        const x = 60 + c * (bw + 10);
+        const y = 60 + r * (bh + 10);
+        blocks.push({ x, y, w: bw, h: bh, alive: true });
+      }
+    }
+
+    let animationId: number;
+
+    const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      ctx.fillStyle = 'white';
+      ctx.fillRect(paddleX, canvas.height - 30, paddleWidth, paddleHeight);
+
+      ctx.beginPath();
+      ctx.arc(ball.x, ball.y, ball.r, 0, Math.PI * 2);
+      ctx.fill();
+
+      blocks.forEach((b) => {
+        if (!b.alive) return;
+        ctx.fillStyle = '#f472b6';
+        ctx.fillRect(b.x, b.y, b.w, b.h);
+      });
+
+      if (leftPressed) paddleX -= 5;
+      if (rightPressed) paddleX += 5;
+      paddleX = Math.max(0, Math.min(canvas.width - paddleWidth, paddleX));
+
+      ball.x += ball.dx;
+      ball.y += ball.dy;
+      if (ball.x < ball.r || ball.x > canvas.width - ball.r) ball.dx *= -1;
+      if (ball.y < ball.r || ball.y > canvas.height - ball.r) ball.dy *= -1;
+
+      animationId = requestAnimationFrame(draw);
+    };
+    draw();
+
+    const keyDown = (e: KeyboardEvent) => {
+      if (e.code === 'ArrowLeft') leftPressed = true;
+      if (e.code === 'ArrowRight') rightPressed = true;
+    };
+    const keyUp = (e: KeyboardEvent) => {
+      if (e.code === 'ArrowLeft') leftPressed = false;
+      if (e.code === 'ArrowRight') rightPressed = false;
+    };
+    window.addEventListener('keydown', keyDown);
+    window.addEventListener('keyup', keyUp);
+
+    return () => {
+      window.removeEventListener('resize', resize);
+      window.removeEventListener('keydown', keyDown);
+      window.removeEventListener('keyup', keyUp);
+      cancelAnimationFrame(animationId);
+    };
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/90">
+      <canvas ref={canvasRef} className="w-full h-full" />
+      <button
+        className="absolute top-4 right-4 text-white text-3xl pointer-events-auto"
+        onClick={onClose}
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/pages/videos/arkanoid.tsx
+++ b/pages/videos/arkanoid.tsx
@@ -10,7 +10,7 @@ export default function ArkanoidPage() {
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Arkanoid</h1>
-      <Arkanoid isActive={true} videoId="preview" />
+      <Arkanoid />
     </div>
   );
 }

--- a/pages/videos/index.tsx
+++ b/pages/videos/index.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import Image from 'next/image';
 import dynamic from 'next/dynamic';
 import SectionLayout from '@/components/SectionLayout';
-import Arkanoid from '../../components/ui/game-arkanoid/Arkanoid';
+import ArkanoidOverlay from '@/components/ui/game-arkanoid/ArkanoidOverlay';
 const YouTube = dynamic(() => import('react-youtube'), { ssr: false });
 
 interface PlaylistItemsApiResponse {
@@ -21,9 +21,10 @@ interface VideosPageProps {
 
 // ─── 2) COMPONENTE PRINCIPAL ─────────────────────────────────────────────
 const VideosPage: React.FC<VideosPageProps> = ({ videos }) => {
-  const [activeVideo, setActiveVideo] = useState<string | null>(null);
+  const [showGame, setShowGame] = useState(false);
 
   return (
+    <>
     <SectionLayout className="relative bg-gray-900 text-white">
       {/* — Fantasma animado como fondo — */}
       <div className="absolute inset-0 pointer-events-none overflow-hidden">
@@ -39,40 +40,37 @@ const VideosPage: React.FC<VideosPageProps> = ({ videos }) => {
 
       {/* — CONTENIDO EN PRIMER PLANO — */}
       <div className="relative z-10 px-4">
+        <button
+          className="mb-6 px-4 py-2 rounded bg-pink-600 text-white hover:bg-pink-700 font-semibold transition"
+          onClick={() => setShowGame(true)}
+        >
+          🚀 Jugar Arkanoid
+        </button>
         <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {videos.map((v) => (
             <div
               key={v}
-              className="relative aspect-video w-full overflow-hidden rounded-lg border border-neutral-700 group"
+              className="relative aspect-video w-full overflow-hidden rounded-lg border border-neutral-700"
             >
-              {activeVideo === v ? (
-                <div className="absolute inset-0 w-full h-full">
-                  <Arkanoid isActive videoId={v} />
-                </div>
-              ) : (
-
-                <YouTube
-                  videoId={v}
-                  className="absolute inset-0 w-full h-full"
-                  iframeClassName="w-full h-full"
-                  opts={{
-                    width: '100%',
-                    height: '100%',
-                    playerVars: { playsinline: 1 },
-                  }}
-                />
-              )}
-              <button
-                onClick={() => setActiveVideo(v)}
-                className="absolute inset-0 flex items-center justify-center bg-black/50 text-white opacity-0 group-hover:opacity-100 transition"
-              >
-                ▶️ Jugar Arkanoid
-              </button>
+              <YouTube
+                videoId={v}
+                className="absolute inset-0 w-full h-full"
+                iframeClassName="w-full h-full"
+                opts={{
+                  width: '100%',
+                  height: '100%',
+                  playerVars: { playsinline: 1 },
+                }}
+              />
             </div>
           ))}
         </div>
       </div>
     </SectionLayout>
+    {showGame && (
+      <ArkanoidOverlay onClose={() => setShowGame(false)} />
+    )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- remove embedded Arkanoid instances from the videos page
- add a single **Jugar Arkanoid** button that opens a new overlay
- implement `<ArkanoidOverlay>` with basic game logic
- simplify `Arkanoid` component API
- update standalone Arkanoid page to new API

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react' ...)*
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9ebe9304832e99516cc9c50ed06e