### PR TITLE
Fix youtube thumbnails and storage parsing

### DIFF
--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export interface Score {
+  name: string;
+  points: number;
+}
+
+export default function Leaderboard() {
+  const [scores, setScores] = useState<Score[]>([]);
+
+  useEffect(() => {
+    const raw = localStorage.getItem('arkanoid-scores');
+    let parsed: Score[] = [];
+    try {
+      parsed = raw ? JSON.parse(raw) : [];
+    } catch {
+      console.warn('LocalStorage arkanoid-scores corrupto; se reinicia.');
+      localStorage.removeItem('arkanoid-scores');
+    }
+    setScores(parsed);
+  }, []);
+
+  return (
+    <div className="space-y-2">
+      {scores.length === 0 && <p>No hay puntuaciones.</p>}
+      {scores.map((s, idx) => (
+        <div key={idx} className="flex justify-between">
+          <span>{s.name}</span>
+          <span>{s.points}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function saveScore(next: Score) {
+  const raw = localStorage.getItem('arkanoid-scores');
+  let scores: Score[] = [];
+  try {
+    scores = raw ? JSON.parse(raw) : [];
+  } catch {
+    console.warn('LocalStorage arkanoid-scores corrupto; se reinicia.');
+    localStorage.removeItem('arkanoid-scores');
+  }
+  const nextScores = [...scores, next];
+  localStorage.setItem('arkanoid-scores', JSON.stringify(nextScores));
+}

--- a/components/ui/game-arkanoid/ArkanoidOverlay.tsx
+++ b/components/ui/game-arkanoid/ArkanoidOverlay.tsx
@@ -4,7 +4,6 @@
 import { useEffect, useRef, useState } from 'react';
 
 interface Props {
-  videoRects: DOMRect[];
   videoIds: string[];
   onVideoHit: (id: string) => void;
   onClose: () => void;
@@ -90,7 +89,6 @@ function hitAABB(b: { x: number; y: number; r: number }, t: Brick) {
 }
 
 export default function ArkanoidOverlay({
-  videoRects,
   videoIds,
   onVideoHit,
   onClose,
@@ -114,7 +112,6 @@ export default function ArkanoidOverlay({
     if (!ctx) return;
     let bricks: Brick[] = [];
     let victory = false;
-    let score = 0;
 
     interface Particle {
       x: number;
@@ -141,8 +138,9 @@ export default function ArkanoidOverlay({
         });
       }
     }
-    const domElems = videoIds.map((id) =>
-      document.querySelector(`[data-video-id="${id}"]`),
+    const domElems = videoIds.map(
+      (id) =>
+        document.querySelector(`[data-video-id="${id}"]`) as HTMLElement | null,
     );
 
     function createBricks() {
@@ -305,11 +303,14 @@ export default function ArkanoidOverlay({
           }
         } else {
           bricksToDelete.push(b);
-          score += 10;
         }
       });
       bricks = bricks.filter((b) => !bricksToDelete.includes(b));
-      if (bricks.every((bk) => bk.isTrigger) && bricksToDelete.length > 0 && !victory) {
+      if (
+        bricks.every((bk) => bk.isTrigger) &&
+        bricksToDelete.length > 0 &&
+        !victory
+      ) {
         victory = true;
         startFireworks();
         setTimeout(onClose, 4000);

--- a/pages/videos/index.tsx
+++ b/pages/videos/index.tsx
@@ -81,6 +81,15 @@ const VideosPage: React.FC<VideosPageProps> = ({ videos }) => {
                 }}
                 className="relative aspect-video w-full overflow-hidden rounded-lg border border-neutral-700"
               >
+                <Image
+                  src={`https://i.ytimg.com/vi/${v}/hqdefault.jpg`}
+                  alt="thumb"
+                  fill
+                  sizes="(max-width:600px) 100vw, 25vw"
+                  className="object-cover rounded-lg"
+                  placeholder="blur"
+                  blurDataURL="/images/thumb-placeholder.jpg"
+                />
                 <YouTube
                   videoId={v}
                   onReady={(e) => {
@@ -102,7 +111,6 @@ const VideosPage: React.FC<VideosPageProps> = ({ videos }) => {
       </SectionLayout>
       {showGame && (
         <ArkanoidOverlay
-          videoRects={videoRectsRef.current}
           videoIds={videos}
           onVideoHit={handleVideoHit}
           onClose={() => setShowGame(false)}


### PR DESCRIPTION
## Summary
- guard null returns from `querySelector`
- show thumbnails using i.ytimg.com
- add simple leaderboard with safe localStorage parsing
- remove unused props in Arkanoid overlay

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d0fba7fb4832eb159cec8771ff2a8