### PR TITLE
Enable ball relaunch after each miss

### DIFF
--- a/components/ui/game-arkanoid/ArkanoidOverlay.tsx
+++ b/components/ui/game-arkanoid/ArkanoidOverlay.tsx
@@ -41,6 +41,8 @@ export default function ArkanoidOverlay({
 }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [livesState, setLivesState] = useState(3);
+  const [started, setStarted] = useState(false);
+  const launchBallRef = useRef<() => void>(() => {});
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
@@ -155,6 +157,7 @@ export default function ArkanoidOverlay({
       ball.dy = -baseSpeed * speedFactor || -2;
       ballAttached = false;
     }
+    launchBallRef.current = launchBall;
 
     function resizeCanvas() {
       if (!canvasRef.current) return;
@@ -309,6 +312,7 @@ export default function ArkanoidOverlay({
         ballAttached = true;
         ball.dx = ball.dy = 0;
         stickBallToPaddle();
+        setStarted(false);
       }
 
       const dirX = Math.sign(ball.dx);
@@ -330,18 +334,43 @@ export default function ArkanoidOverlay({
     window.addEventListener('keydown', keyDown, { passive: true });
     window.addEventListener('keyup', keyUp, { passive: true });
 
+    const handleTouch = (e: TouchEvent) => {
+      e.preventDefault();
+      const touch = e.touches[0];
+      const rect = canvasEl.getBoundingClientRect();
+      paddle.x = touch.clientX - rect.left - paddle.w / 2;
+    };
+    canvasEl.addEventListener('touchstart', handleTouch, { passive: false });
+    canvasEl.addEventListener('touchmove', handleTouch, { passive: false });
+
     canvasEl.focus();
 
     return () => {
       window.removeEventListener('resize', resizeCanvas);
       window.removeEventListener('keydown', keyDown);
       window.removeEventListener('keyup', keyUp);
+      canvasEl.removeEventListener('touchstart', handleTouch);
+      canvasEl.removeEventListener('touchmove', handleTouch);
       cancelAnimationFrame(animationId);
     };
   }, []);
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/90 pointer-events-none">
+    <div className="fixed inset-0 z-50 bg-black/90 pointer-events-auto">
+      {!started && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-4">
+          <p className="text-white text-2xl">Pulsa empezar para jugar</p>
+          <button
+            className="bg-white text-black px-4 py-2 rounded"
+            onClick={() => {
+              setStarted(true);
+              launchBallRef.current();
+            }}
+          >
+            Empezar
+          </button>
+        </div>
+      )}
       <div className="absolute top-4 left-4 text-white text-xl pointer-events-none">
         {Array(livesState).fill('♥').join('')}
       </div>


### PR DESCRIPTION
## Summary
- show the start overlay when a life is lost
- resume play by launching the ball when pressing **Empezar**

## Testing
- `npm install`
- `npm test`
- `npm run lint` *(fails: Expected an assignment or function call in pages/videos/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_685e74c04b2c832e9efdb5d4bf8d89e3