### PR TITLE
Add mobile controls overlay for fighter game

### DIFF
--- a/components/fight/FightScene.tsx
+++ b/components/fight/FightScene.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import MobileControls from './MobileControls';
+import { isMobile } from '@/helpers/mobile';
+import Phaser from 'phaser';
+import BootScene from 'game-fighter/src/scenes/BootScene';
+import PreloadScene from 'game-fighter/src/scenes/PreloadScene';
+import FightScenePhaser from 'game-fighter/src/scenes/FightScene';
+import GameOverScene from 'game-fighter/src/scenes/GameOverScene';
+import VictoryScene from 'game-fighter/src/scenes/VictoryScene';
+import RoundManager from 'game-fighter/src/game/RoundManager';
+
+interface Props {
+  onSolved: () => void;
+}
+
+export default function FightScene({ onSolved }: Props) {
+  const container = useRef<HTMLDivElement>(null);
+  const gameRef = useRef<Phaser.Game | null>(null);
+  const [dir, setDir] = useState<'left' | 'right' | 'up' | 'down' | 'none'>('none');
+  const [punch, setPunch] = useState(false);
+  const [kick, setKick] = useState(false);
+
+  useEffect(() => {
+    if (!container.current) return;
+
+    gameRef.current = new Phaser.Game({
+      type: Phaser.AUTO,
+      parent: container.current,
+      width: 800,
+      height: 600,
+      backgroundColor: '#000',
+      physics: { default: 'arcade', arcade: { gravity: { x: 0, y: 980 } } },
+      scene: [BootScene, PreloadScene, FightScenePhaser, GameOverScene, VictoryScene],
+    });
+
+    gameRef.current.events.once('minigameSolved', () => {
+      gameRef.current?.scene.getScenes(true).forEach((s) => s.scene.pause());
+      onSolved();
+    });
+
+    const canvas = container.current.querySelector('canvas');
+    const prevent = (e: Event) => e.preventDefault();
+    const opt = { passive: false } as AddEventListenerOptions;
+    canvas?.addEventListener('touchstart', prevent, opt);
+    canvas?.addEventListener('touchmove', prevent, opt);
+
+    return () => {
+      canvas?.removeEventListener('touchstart', prevent);
+      canvas?.removeEventListener('touchmove', prevent);
+      RoundManager.stopEnemyAI();
+      gameRef.current?.destroy(true);
+    };
+  }, [onSolved]);
+
+  const dispatchKey = (code: string, type: 'keydown' | 'keyup') => {
+    const evt = new KeyboardEvent(type, { code });
+    window.dispatchEvent(evt);
+  };
+
+  const lastDir = useRef<'left' | 'right' | 'up' | 'down' | 'none'>('none');
+  useEffect(() => {
+    const map: Record<typeof dir, string> = {
+      left: 'ArrowLeft',
+      right: 'ArrowRight',
+      up: 'ArrowUp',
+      down: 'ArrowDown',
+      none: '',
+    };
+    if (lastDir.current !== 'none') {
+      dispatchKey(map[lastDir.current], 'keyup');
+    }
+    if (dir !== 'none') {
+      dispatchKey(map[dir], 'keydown');
+    }
+    lastDir.current = dir;
+  }, [dir]);
+
+  useEffect(() => {
+    dispatchKey('KeyA', punch ? 'keydown' : 'keyup');
+  }, [punch]);
+
+  useEffect(() => {
+    dispatchKey('KeyS', kick ? 'keydown' : 'keyup');
+  }, [kick]);
+
+  const mobile = isMobile();
+
+  return (
+    <div ref={container} className="relative w-full h-full">
+      {mobile && (
+        <MobileControls
+          onDir={(d) => setDir(d)}
+          onAction={(btn, down) => {
+            if (btn === 'A') setPunch(down);
+            if (btn === 'B') setKick(down);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/fight/MobileControls.tsx
+++ b/components/fight/MobileControls.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef } from 'react';
+
+export interface MobileControlsProps {
+  onDir: (dir: 'left' | 'right' | 'up' | 'down' | 'none') => void;
+  onAction: (btn: 'A' | 'B', pressed: boolean) => void;
+}
+
+export default function MobileControls({ onDir, onAction }: MobileControlsProps) {
+  const stickBase = useRef<HTMLDivElement>(null);
+  const aBtn = useRef<HTMLButtonElement>(null);
+  const bBtn = useRef<HTMLButtonElement>(null);
+
+  const lastDir = useRef<'left' | 'right' | 'up' | 'down' | 'none'>('none');
+  const interval = useRef<number>();
+  const start = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const base = stickBase.current;
+    if (!base) return;
+
+    const opt = { passive: false } as AddEventListenerOptions;
+
+    const handleStart = (e: TouchEvent) => {
+      e.preventDefault();
+      const t = e.touches[0];
+      if (!t) return;
+      start.current = { x: t.clientX, y: t.clientY };
+      interval.current = window.setInterval(() => {
+        onDir(lastDir.current);
+      }, 50);
+    };
+
+    const handleMove = (e: TouchEvent) => {
+      e.preventDefault();
+      const t = e.touches[0];
+      if (!t) return;
+      const dx = t.clientX - start.current.x;
+      const dy = t.clientY - start.current.y;
+      const ax = Math.abs(dx);
+      const ay = Math.abs(dy);
+      if (ax < 10 && ay < 10) {
+        lastDir.current = 'none';
+        return;
+      }
+      if (ax > ay) {
+        lastDir.current = dx < 0 ? 'left' : 'right';
+      } else {
+        lastDir.current = dy < 0 ? 'up' : 'down';
+      }
+    };
+
+    const end = (e: TouchEvent) => {
+      e.preventDefault();
+      lastDir.current = 'none';
+      onDir('none');
+      if (interval.current) window.clearInterval(interval.current);
+    };
+
+    base.addEventListener('touchstart', handleStart, opt);
+    base.addEventListener('touchmove', handleMove, opt);
+    base.addEventListener('touchend', end, opt);
+    base.addEventListener('touchcancel', end, opt);
+
+    return () => {
+      base.removeEventListener('touchstart', handleStart);
+      base.removeEventListener('touchmove', handleMove);
+      base.removeEventListener('touchend', end);
+      base.removeEventListener('touchcancel', end);
+      if (interval.current) window.clearInterval(interval.current);
+    };
+  }, [onDir]);
+
+  useEffect(() => {
+    const a = aBtn.current;
+    const b = bBtn.current;
+    if (!a || !b) return;
+    const opt = { passive: false } as AddEventListenerOptions;
+
+    const startA = (e: TouchEvent) => {
+      e.preventDefault();
+      onAction('A', true);
+    };
+    const endA = (e: TouchEvent) => {
+      e.preventDefault();
+      onAction('A', false);
+    };
+    const startB = (e: TouchEvent) => {
+      e.preventDefault();
+      onAction('B', true);
+    };
+    const endB = (e: TouchEvent) => {
+      e.preventDefault();
+      onAction('B', false);
+    };
+
+    a.addEventListener('touchstart', startA, opt);
+    a.addEventListener('touchend', endA, opt);
+    a.addEventListener('touchcancel', endA, opt);
+    b.addEventListener('touchstart', startB, opt);
+    b.addEventListener('touchend', endB, opt);
+    b.addEventListener('touchcancel', endB, opt);
+
+    return () => {
+      a.removeEventListener('touchstart', startA);
+      a.removeEventListener('touchend', endA);
+      a.removeEventListener('touchcancel', endA);
+      b.removeEventListener('touchstart', startB);
+      b.removeEventListener('touchend', endB);
+      b.removeEventListener('touchcancel', endB);
+    };
+  }, [onAction]);
+
+  return (
+    <>
+      <div ref={stickBase} className="stick-base">
+        <div className="stick-knob" />
+      </div>
+      <button ref={aBtn} className="btn-a">A</button>
+      <button ref={bBtn} className="btn-b">B</button>
+    </>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 // pages/_app.tsx
 import '../styles/globals.css';
+import '../styles/fight-controls.css';
 import type { AppProps } from 'next/app';
 import AvatarGuide from '@components/AvatarGuide';
 import Nav from '@components/Nav';

--- a/styles/fight-controls.css
+++ b/styles/fight-controls.css
@@ -1,0 +1,13 @@
+.stick-base {
+  @apply w-24 h-24 rounded-full bg-white/10 fixed left-4 bottom-4;
+  touch-action: none;
+}
+.stick-knob {
+  @apply w-12 h-12 rounded-full bg-white/30 translate-x-1/2 translate-y-1/2;
+}
+.btn-a {
+  @apply w-16 h-16 rounded-full bg-pink-600 fixed right-20 bottom-6 text-white text-lg flex items-center justify-center;
+}
+.btn-b {
+  @apply w-16 h-16 rounded-full bg-blue-600 fixed right-4 bottom-20 text-white text-lg flex items-center justify-center;
+}


### PR DESCRIPTION
## Summary
- create `MobileControls` component with analog stick and action buttons
- add `FightScene` wrapper that integrates Phaser game and uses mobile controls
- style the controls and import CSS globally

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7cf403cc832ea300263ae172bf99