### PR TITLE
Add mobile joystick overlay

### DIFF
--- a/components/fight/FightScene.tsx
+++ b/components/fight/FightScene.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import MobileControls from './MobileControls';
+import { isMobile } from '@/helpers/is-mobile';
+import Phaser from 'phaser';
+import BootScene from 'game-fighter/src/scenes/BootScene';
+import PreloadScene from 'game-fighter/src/scenes/PreloadScene';
+import FightScenePhaser from 'game-fighter/src/scenes/FightScene';
+import GameOverScene from 'game-fighter/src/scenes/GameOverScene';
+import VictoryScene from 'game-fighter/src/scenes/VictoryScene';
+import RoundManager from 'game-fighter/src/game/RoundManager';
+
+interface Props {
+  onSolved: () => void;
+}
+
+export default function FightScene({ onSolved }: Props) {
+  const container = useRef<HTMLDivElement>(null);
+  const gameRef = useRef<Phaser.Game | null>(null);
+  const [dir, setDir] = useState<'left' | 'right' | 'up' | 'down' | 'none'>(
+    'none',
+  );
+  const [punch, setPunch] = useState(false);
+  const [kick, setKick] = useState(false);
+
+  useEffect(() => {
+    if (!container.current) return;
+
+    gameRef.current = new Phaser.Game({
+      type: Phaser.AUTO,
+      parent: container.current,
+      width: 800,
+      height: 600,
+      backgroundColor: '#000',
+      physics: { default: 'arcade', arcade: { gravity: { x: 0, y: 980 } } },
+      scene: [
+        BootScene,
+        PreloadScene,
+        FightScenePhaser,
+        GameOverScene,
+        VictoryScene,
+      ],
+    });
+
+    gameRef.current.events.once('minigameSolved', () => {
+      gameRef.current?.scene.getScenes(true).forEach((s) => s.scene.pause());
+      onSolved();
+    });
+
+    const canvas = container.current.querySelector('canvas');
+    const prevent = (e: Event) => e.preventDefault();
+    const opt = { passive: false } as AddEventListenerOptions;
+    canvas?.addEventListener('touchstart', prevent, opt);
+    canvas?.addEventListener('touchmove', prevent, opt);
+
+    return () => {
+      canvas?.removeEventListener('touchstart', prevent);
+      canvas?.removeEventListener('touchmove', prevent);
+      RoundManager.stopEnemyAI();
+      gameRef.current?.destroy(true);
+    };
+  }, [onSolved]);
+
+  const dispatchKey = (code: string, type: 'keydown' | 'keyup') => {
+    const evt = new KeyboardEvent(type, { code });
+    window.dispatchEvent(evt);
+  };
+
+  const lastDir = useRef<'left' | 'right' | 'up' | 'down' | 'none'>('none');
+  useEffect(() => {
+    const map: Record<typeof dir, string> = {
+      left: 'ArrowLeft',
+      right: 'ArrowRight',
+      up: 'ArrowUp',
+      down: 'ArrowDown',
+      none: '',
+    };
+    if (lastDir.current !== 'none') {
+      dispatchKey(map[lastDir.current], 'keyup');
+    }
+    if (dir !== 'none') {
+      dispatchKey(map[dir], 'keydown');
+    }
+    lastDir.current = dir;
+  }, [dir]);
+
+  useEffect(() => {
+    dispatchKey('KeyA', punch ? 'keydown' : 'keyup');
+  }, [punch]);
+
+  useEffect(() => {
+    dispatchKey('KeyS', kick ? 'keydown' : 'keyup');
+  }, [kick]);
+
+  const mobile = isMobile();
+
+  return (
+    <div ref={container} className="relative w-full h-full">
+      {mobile && (
+        <MobileControls
+          onDir={(d) => setDir(d)}
+          onAction={(btn, down) => {
+            if (btn === 'A') setPunch(down);
+            if (btn === 'B') setKick(down);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/fight/MobileControls.tsx
+++ b/components/fight/MobileControls.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef } from 'react';
+
+export interface MobileControlsProps {
+  onDir: (dir: 'left' | 'right' | 'up' | 'down' | 'none') => void;
+  onAction: (btn: 'A' | 'B', pressed: boolean) => void;
+}
+
+export default function MobileControls({
+  onDir,
+  onAction,
+}: MobileControlsProps) {
+  const stickBase = useRef<HTMLDivElement>(null);
+  const stickKnob = useRef<HTMLDivElement>(null);
+  const aBtn = useRef<HTMLButtonElement>(null);
+  const bBtn = useRef<HTMLButtonElement>(null);
+
+  const lastDir = useRef<'left' | 'right' | 'up' | 'down' | 'none'>('none');
+  const interval = useRef<number | undefined>(undefined);
+  const start = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const base = stickBase.current;
+    if (!base) return;
+
+    const opt = { passive: false } as AddEventListenerOptions;
+
+    const handleStart = (e: TouchEvent) => {
+      e.preventDefault();
+      const t = e.touches[0];
+      if (!t) return;
+      start.current = { x: t.clientX, y: t.clientY };
+      if (stickKnob.current) {
+        stickKnob.current.style.transform = 'translate(-50%, -50%)';
+      }
+      interval.current = window.setInterval(() => {
+        onDir(lastDir.current);
+      }, 50);
+    };
+
+    const handleMove = (e: TouchEvent) => {
+      e.preventDefault();
+      const t = e.touches[0];
+      if (!t) return;
+      const dx = t.clientX - start.current.x;
+      const dy = t.clientY - start.current.y;
+      if (stickKnob.current) {
+        const clamp = (v: number) => Math.max(-24, Math.min(24, v));
+        stickKnob.current.style.transform = `translate(-50%, -50%) translate(${clamp(dx)}px, ${clamp(dy)}px)`;
+      }
+      const ax = Math.abs(dx);
+      const ay = Math.abs(dy);
+      if (ax < 10 && ay < 10) {
+        lastDir.current = 'none';
+        return;
+      }
+      if (ax > ay) {
+        lastDir.current = dx < 0 ? 'left' : 'right';
+      } else {
+        lastDir.current = dy < 0 ? 'up' : 'down';
+      }
+    };
+
+    const end = (e: TouchEvent) => {
+      e.preventDefault();
+      lastDir.current = 'none';
+      if (stickKnob.current) {
+        stickKnob.current.style.transform = 'translate(-50%, -50%)';
+      }
+      onDir('none');
+      if (interval.current) window.clearInterval(interval.current);
+    };
+
+    base.addEventListener('touchstart', handleStart, opt);
+    base.addEventListener('touchmove', handleMove, opt);
+    base.addEventListener('touchend', end, opt);
+    base.addEventListener('touchcancel', end, opt);
+
+    return () => {
+      base.removeEventListener('touchstart', handleStart);
+      base.removeEventListener('touchmove', handleMove);
+      base.removeEventListener('touchend', end);
+      base.removeEventListener('touchcancel', end);
+      if (interval.current) window.clearInterval(interval.current);
+    };
+  }, [onDir]);
+
+  useEffect(() => {
+    const a = aBtn.current;
+    const b = bBtn.current;
+    if (!a || !b) return;
+    const opt = { passive: false } as AddEventListenerOptions;
+
+    const startA = (e: TouchEvent) => {
+      e.preventDefault();
+      onAction('A', true);
+    };
+    const endA = (e: TouchEvent) => {
+      e.preventDefault();
+      onAction('A', false);
+    };
+    const startB = (e: TouchEvent) => {
+      e.preventDefault();
+      onAction('B', true);
+    };
+    const endB = (e: TouchEvent) => {
+      e.preventDefault();
+      onAction('B', false);
+    };
+
+    a.addEventListener('touchstart', startA, opt);
+    a.addEventListener('touchend', endA, opt);
+    a.addEventListener('touchcancel', endA, opt);
+    b.addEventListener('touchstart', startB, opt);
+    b.addEventListener('touchend', endB, opt);
+    b.addEventListener('touchcancel', endB, opt);
+
+    return () => {
+      a.removeEventListener('touchstart', startA);
+      a.removeEventListener('touchend', endA);
+      a.removeEventListener('touchcancel', endA);
+      b.removeEventListener('touchstart', startB);
+      b.removeEventListener('touchend', endB);
+      b.removeEventListener('touchcancel', endB);
+    };
+  }, [onAction]);
+
+  return (
+    <>
+      <div ref={stickBase} className="stick-base">
+        <div ref={stickKnob} className="stick-knob" />
+      </div>
+      <button ref={aBtn} className="btn-a">
+        A
+      </button>
+      <button ref={bBtn} className="btn-b">
+        B
+      </button>
+    </>
+  );
+}

--- a/components/ui/GameFighter.tsx
+++ b/components/ui/GameFighter.tsx
@@ -1,10 +1,18 @@
 // components/ui/GameFighter.tsx
 'use client';
 
-import { forwardRef, useImperativeHandle, useEffect, useRef } from 'react';
+import {
+  forwardRef,
+  useImperativeHandle,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { qs } from '@/lib/safe-dom';
 import RoundManager from 'game-fighter/src/game/RoundManager';
 import Phaser from 'phaser';
+import MobileControls from '@components/fight/MobileControls';
+import { isMobile } from '@/helpers/is-mobile';
 
 import BootScene from 'game-fighter/src/scenes/BootScene';
 import PreloadScene from 'game-fighter/src/scenes/PreloadScene';
@@ -31,6 +39,12 @@ const GameFighter = forwardRef<GameFighterHandle, Props>(
   ({ onSolved }, ref) => {
     const container = useRef<HTMLDivElement>(null);
     const gameRef = useRef<Phaser.Game | null>(null);
+    const [dir, setDir] = useState<'left' | 'right' | 'up' | 'down' | 'none'>(
+      'none',
+    );
+    const [punch, setPunch] = useState(false);
+    const [kick, setKick] = useState(false);
+    const [showControls, setShowControls] = useState(false);
 
     const destroyGame = () => {
       RoundManager.stopEnemyAI();
@@ -71,9 +85,46 @@ const GameFighter = forwardRef<GameFighterHandle, Props>(
         onSolved();
       });
 
+      const show = () => setShowControls(isMobile());
+      gameRef.current.events.on('show-controls', show);
+
       /* limpieza segura */
-      return destroyGame;
+      return () => {
+        gameRef.current?.events.off('show-controls', show);
+        destroyGame();
+      };
     }, [onSolved]);
+
+    const dispatchKey = (code: string, type: 'keydown' | 'keyup') => {
+      const evt = new KeyboardEvent(type, { code });
+      window.dispatchEvent(evt);
+    };
+
+    const lastDir = useRef<'left' | 'right' | 'up' | 'down' | 'none'>('none');
+    useEffect(() => {
+      const map: Record<typeof dir, string> = {
+        left: 'ArrowLeft',
+        right: 'ArrowRight',
+        up: 'ArrowUp',
+        down: 'ArrowDown',
+        none: '',
+      };
+      if (lastDir.current !== 'none') {
+        dispatchKey(map[lastDir.current], 'keyup');
+      }
+      if (dir !== 'none') {
+        dispatchKey(map[dir], 'keydown');
+      }
+      lastDir.current = dir;
+    }, [dir]);
+
+    useEffect(() => {
+      dispatchKey('KeyA', punch ? 'keydown' : 'keyup');
+    }, [punch]);
+
+    useEffect(() => {
+      dispatchKey('KeyS', kick ? 'keydown' : 'keyup');
+    }, [kick]);
 
     /* ------------------------------------------------ */
     return (
@@ -82,7 +133,17 @@ const GameFighter = forwardRef<GameFighterHandle, Props>(
         /* tabIndex permite recibir foco vía keyboard/nav */
         tabIndex={0}
         className="absolute inset-0 z-20 flex items-center justify-center bg-black/75"
-      />
+      >
+        {showControls && (
+          <MobileControls
+            onDir={(d) => setDir(d)}
+            onAction={(btn, down) => {
+              if (btn === 'A') setPunch(down);
+              if (btn === 'B') setKick(down);
+            }}
+          />
+        )}
+      </div>
     );
   },
 );

--- a/game-fighter/src/scenes/FightScene.ts
+++ b/game-fighter/src/scenes/FightScene.ts
@@ -3,6 +3,7 @@ import { Player } from '../game/Player';
 import { HitBox } from '../game/HitBox'; // ⬅️ nuevo import
 import { Enemy } from '../game/Enemy';
 import RoundManager from '../game/RoundManager';
+import { isMobile } from '@/helpers/is-mobile';
 
 //import type { HitData } from '../game/HitBox';
 
@@ -36,6 +37,9 @@ export default class FightScene extends Phaser.Scene {
   create(): void {
     this.canMove = false;
     this.ended = false;
+
+    const mobile = isMobile();
+    if (mobile) this.game.events.emit('show-controls');
 
     // 0️⃣ — Carga animaciones (solo una vez)
     Enemy.createAnimations(this.anims);

--- a/helpers/mobile.ts
+++ b/helpers/mobile.ts
@@ -1,2 +1,0 @@
-export const isMobile = () =>
-  typeof window !== 'undefined' && window.innerWidth <= 640;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 // pages/_app.tsx
 import '../styles/globals.css';
+import '../styles/fight-controls.css';
 import type { AppProps } from 'next/app';
 import AvatarGuide from '@components/AvatarGuide';
 import Nav from '@components/Nav';

--- a/pages/videos/index.tsx
+++ b/pages/videos/index.tsx
@@ -54,8 +54,13 @@ const VideosPage: React.FC<VideosPageProps> = ({ videos }) => {
 
     const state = await player.getPlayerState();
     const playing = state === 1;
-    playing ? player.pauseVideo() : player.playVideo();
-    currentPlaying.current = playing ? null : id;
+    if (playing) {
+      player.pauseVideo();
+      currentPlaying.current = null;
+    } else {
+      player.playVideo();
+      currentPlaying.current = id;
+    }
   }, []);
 
   return (
@@ -118,10 +123,8 @@ const VideosPage: React.FC<VideosPageProps> = ({ videos }) => {
                     {/* iframe */}
                     <YouTube
                       videoId={v}
-                      onReady={(e) => {
-                        // @ts-ignore: e.target is the YouTube Player instance
+                      onReady={(e: { target: YouTubePlayer }) => {
                         playersRef.current[v] = e.target;
-                        // @ts-ignore
                         e.target.mute();
                       }}
                       className="absolute inset-0 w-full h-full"

--- a/styles/fight-controls.css
+++ b/styles/fight-controls.css
@@ -1,0 +1,13 @@
+.stick-base {
+  @apply w-24 h-24 rounded-full bg-white/10 fixed left-4 bottom-4 relative;
+  touch-action: none;
+}
+.stick-knob {
+  @apply absolute top-1/2 left-1/2 w-12 h-12 rounded-full bg-white/30 -translate-x-1/2 -translate-y-1/2 transition-transform;
+}
+.btn-a {
+  @apply w-16 h-16 rounded-full bg-pink-600 fixed right-20 bottom-6 text-white text-lg flex items-center justify-center;
+}
+.btn-b {
+  @apply w-16 h-16 rounded-full bg-blue-600 fixed right-4 bottom-20 text-white text-lg flex items-center justify-center;
+}


### PR DESCRIPTION
## Summary
- add knob tracking in `MobileControls`
- style the joystick knob with transition effect
- show controls on mobile via Phaser's `show-controls` event
- refine CSS for joystick positioning
- remove outdated helper

## Testing
- `npm test`
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_685e7cf403cc832ea300263ae172bf99