### PR TITLE
Add reactive game state

### DIFF
--- a/src/vue/PacmanMusicGame.vue
+++ b/src/vue/PacmanMusicGame.vue
@@ -1,0 +1,26 @@
+<template>
+  <div
+    class="flex items-center justify-center min-h-screen bg-gray-900 relative"
+  >
+    <canvas width="480" height="640" class="bg-black"></canvas>
+    <div class="absolute top-2 left-2 text-white space-x-4">
+      <span>Vidas: {{ state.lives }}</span>
+      <span>Puntuación: {{ state.score }}</span>
+      <span>Nivel: {{ state.level }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useGameState } from '@/vue/gameState';
+
+const { state, addScore, nextLevel, loseLife, resetGame } = useGameState();
+
+// Game logic will use these actions
+</script>
+
+<style scoped>
+canvas {
+  image-rendering: pixelated;
+}
+</style>

--- a/src/vue/gameState.ts
+++ b/src/vue/gameState.ts
@@ -1,0 +1,48 @@
+import { reactive, computed } from 'vue';
+
+export interface GameState {
+  score: number;
+  level: number;
+  lives: number;
+}
+
+const initialState: GameState = {
+  score: 0,
+  level: 1,
+  lives: 3,
+};
+
+const state = reactive<GameState>({ ...initialState });
+
+const hasLives = computed(() => state.lives > 0);
+const isGameOver = computed(() => !hasLives.value);
+
+function addScore(amount: number) {
+  state.score += amount;
+}
+
+function nextLevel() {
+  state.level += 1;
+}
+
+function loseLife() {
+  if (state.lives > 0) {
+    state.lives -= 1;
+  }
+}
+
+function resetGame() {
+  Object.assign(state, initialState);
+}
+
+export function useGameState() {
+  return {
+    state,
+    hasLives,
+    isGameOver,
+    addScore,
+    nextLevel,
+    loseLife,
+    resetGame,
+  };
+}


### PR DESCRIPTION
## Summary
- expose GameState reactive store with helpers
- display store data in PacmanMusicGame.vue

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686502580c98832e9b73967dea7abdd3