### PR TITLE
Add Spotify utilities

### DIFF
--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+
+export interface SpotifyState {
+  token: string | null;
+  sdkReady: boolean;
+  setToken: (t: string | null) => void;
+}
+
+/**
+ * Minimal placeholder hook for Spotify integration.
+ * Loads the Web Playback SDK and exposes the auth token state.
+ */
+export function useSpotify(): SpotifyState {
+  const [token, setToken] = useState<string | null>(null);
+  const [sdkReady, setSdkReady] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const id = 'spotify-sdk';
+    let script = document.getElementById(id) as HTMLScriptElement | null;
+    if (!script) {
+      script = document.createElement('script');
+      script.id = id;
+      script.src = 'https://sdk.scdn.co/spotify-player.js';
+      script.onload = () => setSdkReady(true);
+      document.body.appendChild(script);
+    } else if (window.Spotify) {
+      setSdkReady(true);
+    }
+    window.onSpotifyWebPlaybackSDKReady = () => setSdkReady(true);
+  }, []);
+
+  return { token, sdkReady, setToken };
+}
+
+/**
+ * Plays a random track from the provided list using the Spotify Web API.
+ * Tracks will not repeat until all have been played once.
+ */
+const historyMap: Record<string, string[]> = {};
+
+export async function playRandomTrack(
+  levelSongs: string[],
+  token: string,
+  levelKey = 'default',
+) {
+  if (!token || levelSongs.length === 0) return;
+
+  const history = historyMap[levelKey] || (historyMap[levelKey] = []);
+  const remaining = levelSongs.filter((id) => !history.includes(id));
+  if (remaining.length === 0) {
+    history.length = 0;
+    remaining.push(...levelSongs);
+  }
+  const trackId = remaining[Math.floor(Math.random() * remaining.length)];
+  history.push(trackId);
+
+  try {
+    await fetch('https://api.spotify.com/v1/me/player/play', {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ uris: [`spotify:track:${trackId}`] }),
+    });
+  } catch (err) {
+    console.warn('Failed to play track:', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add `useSpotify` hook to prep auth token and SDK readiness
- implement `playRandomTrack` helper with per-level history to avoid repeats

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650f4482c4832e9426eabe916e4dcf