### PR TITLE
Add Spotify trigger for Pacman

### DIFF
--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -43,7 +43,7 @@ export async function playRandomTrack(
   levelSongs: string[],
   token: string,
   levelKey = 'default',
-) {
+): Promise<string | undefined> {
   if (!token || levelSongs.length === 0) return;
 
   const history = historyMap[levelKey] || (historyMap[levelKey] = []);
@@ -64,7 +64,9 @@ export async function playRandomTrack(
       },
       body: JSON.stringify({ uris: [`spotify:track:${trackId}`] }),
     });
+    return trackId;
   } catch (err) {
     console.warn('Failed to play track:', err);
+    return undefined;
   }
 }


### PR DESCRIPTION
## Summary
- return trackId from `playRandomTrack`
- show current song in `PacmanMusicGame`
- play random Spotify track when a big pellet is eaten

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686512982d0c832e9f289cf438fac519