### PR TITLE
Implement level progression for Pacman

### DIFF
--- a/src/vue/useGhostAI.ts
+++ b/src/vue/useGhostAI.ts
@@ -16,6 +16,7 @@ const COLORS = ['#ff0000', '#ffb8ff', '#00ffff', '#ffb847'];
 
 export function useGhostAI(levelMap: LevelMap, tileSize: number, player: PlayerState) {
   const { state: game } = useGameState();
+  let map = levelMap;
 
   const baseSpeed = tileSize / 8;
   const ghosts = reactive<GhostState[]>(Array.from({ length: 4 }).map((_, i) => ({
@@ -28,7 +29,7 @@ export function useGhostAI(levelMap: LevelMap, tileSize: number, player: PlayerS
 
   let timer: number | undefined;
 
-  const isWalkable = (r: number, c: number) => levelMap[r]?.[c] !== 1;
+  const isWalkable = (r: number, c: number) => map[r]?.[c] !== 1;
 
   function bfs(start: { r: number; c: number }, target: { r: number; c: number }) {
     const q: Array<[number, number]> = [[start.r, start.c]];
@@ -122,5 +123,15 @@ export function useGhostAI(levelMap: LevelMap, tileSize: number, player: PlayerS
     if (timer) window.clearInterval(timer);
   });
 
-  return { ghosts, moveGhosts, collidesWithPlayer };
+  function reset(newMap: LevelMap) {
+    map = newMap;
+    ghosts.forEach((g, i) => {
+      g.x = tileSize * (7 + (i % 2));
+      g.y = tileSize * (9 + Math.floor(i / 2));
+      g.path = [];
+    });
+    updatePaths();
+  }
+
+  return { ghosts, moveGhosts, collidesWithPlayer, reset };
 }

--- a/src/vue/usePelletManager.ts
+++ b/src/vue/usePelletManager.ts
@@ -6,22 +6,28 @@ import { useGameState } from './gameState';
 export function usePelletManager(levelMap: LevelMap, tileSize: number) {
   const { addScore } = useGameState();
 
-  const pelletsLeft = ref(
-    levelMap.reduce((count, row) =>
-      count + row.filter((t) => t === 2 || t === 3).length, 0)
-  );
+  let map = levelMap;
+  const countPellets = (m: LevelMap) =>
+    m.reduce((count, row) => count + row.filter((t) => t === 2 || t === 3).length, 0);
+
+  const pelletsLeft = ref(countPellets(map));
 
   function handlePelletCollision(player: PlayerState, onBigPellet: () => void) {
     const row = Math.floor((player.y + player.height / 2) / tileSize);
     const col = Math.floor((player.x + player.width / 2) / tileSize);
-    const tile = levelMap[row]?.[col];
+    const tile = map[row]?.[col];
     if (tile === 2 || tile === 3) {
-      levelMap[row][col] = 0;
+      map[row][col] = 0;
       pelletsLeft.value -= 1;
       addScore(tile === 3 ? 50 : 10);
       if (tile === 3) onBigPellet();
     }
   }
 
-  return { pelletsLeft, handlePelletCollision };
+  function reset(newMap: LevelMap) {
+    map = newMap;
+    pelletsLeft.value = countPellets(map);
+  }
+
+  return { pelletsLeft, handlePelletCollision, reset };
 }

--- a/src/vue/usePlayer.ts
+++ b/src/vue/usePlayer.ts
@@ -12,6 +12,7 @@ export interface PlayerState {
 }
 
 export function usePlayer(levelMap: LevelMap, tileSize: number) {
+  let map = levelMap;
   const state = reactive<PlayerState>({
     x: tileSize,
     y: tileSize,
@@ -53,7 +54,7 @@ export function usePlayer(levelMap: LevelMap, tileSize: number) {
   const isWall = (x: number, y: number) => {
     const col = Math.floor(x / tileSize);
     const row = Math.floor(y / tileSize);
-    return levelMap[row]?.[col] === 1;
+    return map[row]?.[col] === 1;
   };
 
   const collides = (x: number, y: number) => {
@@ -92,6 +93,10 @@ export function usePlayer(levelMap: LevelMap, tileSize: number) {
     state.y = y;
   };
 
+  const setLevelMap = (newMap: LevelMap) => {
+    map = newMap;
+  };
+
   onMounted(() => {
     window.addEventListener('keydown', keydown);
     window.addEventListener('keyup', keyup);
@@ -102,5 +107,5 @@ export function usePlayer(levelMap: LevelMap, tileSize: number) {
     window.removeEventListener('keyup', keyup);
   });
 
-  return { state, update, setPosition };
+  return { state, update, setPosition, setLevelMap };
 }


### PR DESCRIPTION
## Summary
- add level reset hooks to pacman helpers
- restart loops and music when pellets are cleared

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865167cf2c0832ea7289ec184d12b46