### PR TITLE
Add Pac-Man overlay button on Spotify page

### DIFF
--- a/components/ui/pacman/PacmanOverlay.tsx
+++ b/components/ui/pacman/PacmanOverlay.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function PacmanOverlay({ onClose }: { onClose: () => void }) {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80">
+      <div className="space-y-4 rounded-lg bg-gray-900 p-6 text-center text-white">
+        <p className="text-xl font-semibold">Juego de Pac-Man próximamente…</p>
+        <button
+          className="rounded bg-blue-600 px-4 py-2 hover:bg-blue-700"
+          onClick={onClose}
+        >
+          Cerrar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/pages/music/spotify/index.tsx
+++ b/pages/music/spotify/index.tsx
@@ -1,5 +1,12 @@
 // pages/music/spotify/index.tsx
 import SectionLayout from '@components/SectionLayout';
+import { useState } from 'react';
+import dynamic from 'next/dynamic';
+
+const PacmanOverlay = dynamic(
+  () => import('@components/ui/pacman/PacmanOverlay'),
+  { ssr: false },
+);
 
 const trackIds = [
   '5Q3jx7MeOdXMORcYRVrZCr',
@@ -14,6 +21,7 @@ const trackIds = [
 ];
 
 export default function SpotifyPage() {
+  const [showGame, setShowGame] = useState(false);
   return (
     <>
       {/* Declaramos la keyframes dentro de un style jsx global */}+{' '}
@@ -88,6 +96,13 @@ export default function SpotifyPage() {
               />
             ))}
           </div>
+          {/* Botón para iniciar Pac-Man */}
+          <button
+            className="mb-6 px-4 py-2 rounded bg-yellow-600 text-white hover:bg-yellow-700 font-semibold"
+            onClick={() => setShowGame(true)}
+          >
+            🟡 Jugar Pac-Man
+          </button>
           {/* Tu grid de iframes */}
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 px-4">
             {trackIds.map((id) => (
@@ -120,7 +135,8 @@ export default function SpotifyPage() {
             ></iframe>{' '}
           </div>{' '}
         </div>
-      </SectionLayout>
-    </>
-  );
-}
+        </SectionLayout>
+        {showGame && <PacmanOverlay onClose={() => setShowGame(false)} />}
+      </>
+    );
+  }


### PR DESCRIPTION
## Summary
- add PacmanOverlay component as placeholder
- enable Pac-Man overlay button on music/spotify

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest run` *(fails: cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_686535a90558832e8aab66993bc2574b